### PR TITLE
[FEAT] 아파트 관련 API 구현

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -51,6 +51,12 @@ dependencies {
 	implementation 'io.jsonwebtoken:jjwt-api:0.12.3'
 	runtimeOnly 'io.jsonwebtoken:jjwt-impl:0.12.3'
 	runtimeOnly 'io.jsonwebtoken:jjwt-jackson:0.12.3'
+
+	// Querydsl
+	implementation 'com.querydsl:querydsl-jpa:5.0.0:jakarta'
+	annotationProcessor "com.querydsl:querydsl-apt:5.0.0:jakarta"
+	annotationProcessor "jakarta.annotation:jakarta.annotation-api"
+	annotationProcessor "jakarta.persistence:jakarta.persistence-api"
 }
 
 tasks.named('test') {

--- a/src/main/java/com/ssafy/team02_BE/apart/controller/ApartDealsController.java
+++ b/src/main/java/com/ssafy/team02_BE/apart/controller/ApartDealsController.java
@@ -11,8 +11,8 @@ import java.util.List;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PathVariable;
-import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
 
@@ -24,9 +24,9 @@ import org.springframework.web.bind.annotation.RestController;
 public class ApartDealsController {
 	private final ApartDealsService apartDealsService;
 
-	@PostMapping("/{aptSeq}/deals")
+	@GetMapping("/{aptSeq}/deals")
 	@Operation(summary = "aptSeq로 아파트 거래 정보 조회")
-	public ResponseEntity<ApiResponse<List<ApartDeals>>> getApartDealsyAptSeq(@PathVariable String aptSeq) throws Exception {
+	public ResponseEntity<ApiResponse<List<ApartDeals>>> getApartDealsByAptSeq(@PathVariable String aptSeq) throws Exception {
 		return ResponseEntity
 			.status(HttpStatus.OK)
 			.body(ApiResponse.success(

--- a/src/main/java/com/ssafy/team02_BE/apart/controller/ApartDealsController.java
+++ b/src/main/java/com/ssafy/team02_BE/apart/controller/ApartDealsController.java
@@ -1,0 +1,38 @@
+package com.ssafy.team02_BE.apart.controller;
+
+
+import com.ssafy.team02_BE.apart.domain.ApartDeals;
+import com.ssafy.team02_BE.apart.service.ApartDealsService;
+import com.ssafy.team02_BE.common.dto.ApiResponse;
+import com.ssafy.team02_BE.exception.SuccessCode;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import java.util.List;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/map/apart")
+@Tag(name = "ApartDealsController", description = "아파트 거래 관련 기능")
+public class ApartDealsController {
+	private final ApartDealsService apartDealsService;
+
+	@PostMapping("/{aptSeq}/deals")
+	@Operation(summary = "aptSeq로 아파트 거래 정보 조회")
+	public ResponseEntity<ApiResponse<List<ApartDeals>>> getApartDealsyAptSeq(@PathVariable String aptSeq) throws Exception {
+		return ResponseEntity
+			.status(HttpStatus.OK)
+			.body(ApiResponse.success(
+				SuccessCode.GET_APARTDEALS_BY_APTSEQ,
+				apartDealsService.getApartDealsByAptSeq(aptSeq)
+			));
+	}
+
+}

--- a/src/main/java/com/ssafy/team02_BE/apart/controller/ApartInfoController.java
+++ b/src/main/java/com/ssafy/team02_BE/apart/controller/ApartInfoController.java
@@ -1,18 +1,22 @@
 package com.ssafy.team02_BE.apart.controller;
 
 
+import com.ssafy.team02_BE.apart.controller.dto.AptDetailResponseDTO;
 import com.ssafy.team02_BE.apart.domain.ApartInfo;
 import com.ssafy.team02_BE.apart.service.ApartInfoService;
 import com.ssafy.team02_BE.common.dto.ApiResponse;
 import com.ssafy.team02_BE.exception.SuccessCode;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.tags.Tag;
+import java.util.List;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
 
 
@@ -33,7 +37,27 @@ public class ApartInfoController {
 				apartInfoService.getApartInfoByAptSeq(aptSeq)
 			));
 	}
-	
 
+	@GetMapping("/{aptSeq}/detail")
+	@Operation(summary = "aptSeq로 아파트 상세 정보와 거래 정보 조회")
+	private ResponseEntity<ApiResponse<AptDetailResponseDTO>> getApartDetailsByAptSeq(@PathVariable String aptSeq) throws Exception {
+		return ResponseEntity
+			.status(HttpStatus.OK)
+			.body(ApiResponse.success(
+				SuccessCode.GET_APARTDETAILS_BY_APTSEQ,
+				apartInfoService.getApartDetailsByAptSeq(aptSeq)
+			));
+	}
+
+	@GetMapping("")
+	@Operation(summary = "동이름으로 아파트 검색")
+	private ResponseEntity<ApiResponse<List<ApartInfo>>> getApartInfosByDongName(@RequestParam String dongName) throws Exception {
+		return ResponseEntity
+			.status(HttpStatus.OK)
+			.body(ApiResponse.success(
+				SuccessCode.GET_APARTINFOS_BY_DONGNAME,
+				apartInfoService.getApartInfosByDongName(dongName)
+			));
+	}
 
 }

--- a/src/main/java/com/ssafy/team02_BE/apart/controller/ApartInfoController.java
+++ b/src/main/java/com/ssafy/team02_BE/apart/controller/ApartInfoController.java
@@ -14,7 +14,6 @@ import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PathVariable;
-import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
@@ -27,7 +26,7 @@ import org.springframework.web.bind.annotation.RestController;
 public class ApartInfoController {
 	private final ApartInfoService apartInfoService;
 
-	@PostMapping("/{aptSeq}")
+	@GetMapping("/{aptSeq}")
 	@Operation(summary = "aptSeq로 아파트 상세 정보 조회")
 	public ResponseEntity<ApiResponse<ApartInfo>> getApartInfoByAptSeq(@PathVariable String aptSeq) throws Exception {
 		return ResponseEntity
@@ -40,7 +39,7 @@ public class ApartInfoController {
 
 	@GetMapping("/{aptSeq}/detail")
 	@Operation(summary = "aptSeq로 아파트 상세 정보와 거래 정보 조회")
-	private ResponseEntity<ApiResponse<AptDetailResponseDTO>> getApartDetailsByAptSeq(@PathVariable String aptSeq) throws Exception {
+	public ResponseEntity<ApiResponse<AptDetailResponseDTO>> getApartDetailsByAptSeq(@PathVariable String aptSeq) throws Exception {
 		return ResponseEntity
 			.status(HttpStatus.OK)
 			.body(ApiResponse.success(
@@ -51,7 +50,7 @@ public class ApartInfoController {
 
 	@GetMapping("")
 	@Operation(summary = "동이름으로 아파트 검색")
-	private ResponseEntity<ApiResponse<List<ApartInfo>>> getApartInfosByDongName(@RequestParam String dongName) throws Exception {
+	public ResponseEntity<ApiResponse<List<ApartInfo>>> getApartInfosByDongName(@RequestParam String dongName) throws Exception {
 		return ResponseEntity
 			.status(HttpStatus.OK)
 			.body(ApiResponse.success(

--- a/src/main/java/com/ssafy/team02_BE/apart/controller/ApartInfoController.java
+++ b/src/main/java/com/ssafy/team02_BE/apart/controller/ApartInfoController.java
@@ -1,0 +1,39 @@
+package com.ssafy.team02_BE.apart.controller;
+
+
+import com.ssafy.team02_BE.apart.domain.ApartInfo;
+import com.ssafy.team02_BE.apart.service.ApartInfoService;
+import com.ssafy.team02_BE.common.dto.ApiResponse;
+import com.ssafy.team02_BE.exception.SuccessCode;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/map/apart")
+@Tag(name = "ApartInfoController", description = "아파트 상세정보 관련 기능")
+public class ApartInfoController {
+	private final ApartInfoService apartInfoService;
+
+	@PostMapping("/{aptSeq}")
+	@Operation(summary = "aptSeq로 아파트 상세 정보 조회")
+	public ResponseEntity<ApiResponse<ApartInfo>> getApartInfoByAptSeq(@PathVariable String aptSeq) throws Exception {
+		return ResponseEntity
+			.status(HttpStatus.OK)
+			.body(ApiResponse.success(
+				SuccessCode.GET_APARTINFO_BY_APTSEQ,
+				apartInfoService.getApartInfoByAptSeq(aptSeq)
+			));
+	}
+	
+
+
+}

--- a/src/main/java/com/ssafy/team02_BE/apart/controller/dto/AptDetailResponseDTO.java
+++ b/src/main/java/com/ssafy/team02_BE/apart/controller/dto/AptDetailResponseDTO.java
@@ -1,0 +1,26 @@
+package com.ssafy.team02_BE.apart.controller.dto;
+
+import com.ssafy.team02_BE.apart.domain.ApartDeals;
+import com.ssafy.team02_BE.apart.domain.ApartInfo;
+import java.util.List;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@AllArgsConstructor
+@NoArgsConstructor
+@Builder
+public class AptDetailResponseDTO {
+	private String aptSeq;
+	private ApartInfo apartInfo;
+	private List<ApartDeals> apartDeals;
+	public static AptDetailResponseDTO of(String aptSeq, ApartInfo info, List<ApartDeals> deals) {
+		return AptDetailResponseDTO.builder()
+			.aptSeq(aptSeq)
+			.apartInfo(info)
+			.apartDeals(deals)
+			.build();
+	}
+}

--- a/src/main/java/com/ssafy/team02_BE/apart/domain/ApartDeals.java
+++ b/src/main/java/com/ssafy/team02_BE/apart/domain/ApartDeals.java
@@ -1,0 +1,23 @@
+package com.ssafy.team02_BE.apart.domain;
+
+import jakarta.persistence.Entity;
+import jakarta.persistence.Id;
+import lombok.AccessLevel;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Entity
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class ApartDeals {
+	@Id
+	private long no;
+	private String aptSeq;
+	private String aptDong;
+	private String floor;
+	private int dealYear;
+	private int dealMonth;
+	private int dealDay;
+	private Double excluUseAr;
+	private String dealAmount;
+}

--- a/src/main/java/com/ssafy/team02_BE/apart/domain/ApartDeals.java
+++ b/src/main/java/com/ssafy/team02_BE/apart/domain/ApartDeals.java
@@ -2,6 +2,8 @@ package com.ssafy.team02_BE.apart.domain;
 
 import jakarta.persistence.Entity;
 import jakarta.persistence.Id;
+import jakarta.persistence.Index;
+import jakarta.persistence.Table;
 import lombok.AccessLevel;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
@@ -9,6 +11,11 @@ import lombok.NoArgsConstructor;
 @Entity
 @Getter
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
+@Table(
+	indexes = {
+		@Index(name = "idx_apt_seq", columnList = "aptSeq")
+	}
+)
 public class ApartDeals {
 	@Id
 	private long no;

--- a/src/main/java/com/ssafy/team02_BE/apart/domain/ApartInfo.java
+++ b/src/main/java/com/ssafy/team02_BE/apart/domain/ApartInfo.java
@@ -1,0 +1,28 @@
+package com.ssafy.team02_BE.apart.domain;
+
+import jakarta.persistence.Entity;
+import jakarta.persistence.Id;
+import lombok.AccessLevel;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Entity
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class ApartInfo {
+	@Id
+	private String aptSeq;
+	private String sggCd;
+	private String umdCd;
+	private String umdNm;
+	private String jibun;
+	private String roadNmSggCd;
+	private String roadNm;
+	private String roadNmBonbun;
+	private String roadNmBubun;
+	private String aptNm;
+	private int buildYear;
+	private String latitude;
+	private String longitude;
+
+}

--- a/src/main/java/com/ssafy/team02_BE/apart/repository/ApartDealsRepository.java
+++ b/src/main/java/com/ssafy/team02_BE/apart/repository/ApartDealsRepository.java
@@ -6,5 +6,5 @@ import org.springframework.data.jpa.repository.JpaRepository;
 
 public interface ApartDealsRepository extends JpaRepository<ApartDeals, Long> {
 
-    List<ApartDeals> findByAptSeq(String aptSeq);
+    List<ApartDeals> findAllByAptSeq(String aptSeq);
 }

--- a/src/main/java/com/ssafy/team02_BE/apart/repository/ApartDealsRepository.java
+++ b/src/main/java/com/ssafy/team02_BE/apart/repository/ApartDealsRepository.java
@@ -7,4 +7,5 @@ import org.springframework.data.jpa.repository.JpaRepository;
 public interface ApartDealsRepository extends JpaRepository<ApartDeals, Long> {
 
     List<ApartDeals> findAllByAptSeq(String aptSeq);
+    List<ApartDeals> findTop100ByAptSeqOrderByDealYearDescDealMonthDesc(String aptSeq);
 }

--- a/src/main/java/com/ssafy/team02_BE/apart/repository/ApartDealsRepository.java
+++ b/src/main/java/com/ssafy/team02_BE/apart/repository/ApartDealsRepository.java
@@ -1,0 +1,10 @@
+package com.ssafy.team02_BE.apart.repository;
+
+import com.ssafy.team02_BE.apart.domain.ApartDeals;
+import java.util.List;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface ApartDealsRepository extends JpaRepository<ApartDeals, Long> {
+
+    List<ApartDeals> findByAptSeq(String aptSeq);
+}

--- a/src/main/java/com/ssafy/team02_BE/apart/repository/ApartInfoRepository.java
+++ b/src/main/java/com/ssafy/team02_BE/apart/repository/ApartInfoRepository.java
@@ -1,0 +1,10 @@
+package com.ssafy.team02_BE.apart.repository;
+
+import com.ssafy.team02_BE.apart.domain.ApartInfo;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface ApartInfoRepository extends JpaRepository<ApartInfo, String> {
+
+    ApartInfo findByAptSeq(String aptSeq);
+    Boolean existsByAptSeq(String aptSeq);
+}

--- a/src/main/java/com/ssafy/team02_BE/apart/repository/ApartInfoRepository.java
+++ b/src/main/java/com/ssafy/team02_BE/apart/repository/ApartInfoRepository.java
@@ -1,10 +1,11 @@
 package com.ssafy.team02_BE.apart.repository;
 
 import com.ssafy.team02_BE.apart.domain.ApartInfo;
+import java.util.Optional;
 import org.springframework.data.jpa.repository.JpaRepository;
 
 public interface ApartInfoRepository extends JpaRepository<ApartInfo, String> {
 
-    ApartInfo findByAptSeq(String aptSeq);
-    Boolean existsByAptSeq(String aptSeq);
+    Optional<ApartInfo> findByAptSeq(String aptSeq);
+    boolean existsByAptSeq(String aptSeq);
 }

--- a/src/main/java/com/ssafy/team02_BE/apart/repository/ApartQueryRepository.java
+++ b/src/main/java/com/ssafy/team02_BE/apart/repository/ApartQueryRepository.java
@@ -16,7 +16,7 @@ public class ApartQueryRepository {
     /**
      * 동이름으로 아파트 상세 정보 리스트 조회
      */
-    public List<ApartInfo> getHouseInfosByDongName(String dongName) {
+    public List<ApartInfo> getApartInfosByDongName(String dongName) {
         QApartInfo apartInfo = QApartInfo.apartInfo;
         QDongcode dongcode = QDongcode.dongcode;
         return queryFactory

--- a/src/main/java/com/ssafy/team02_BE/apart/repository/ApartQueryRepository.java
+++ b/src/main/java/com/ssafy/team02_BE/apart/repository/ApartQueryRepository.java
@@ -1,0 +1,28 @@
+package com.ssafy.team02_BE.apart.repository;
+
+import com.querydsl.jpa.impl.JPAQueryFactory;
+import com.ssafy.team02_BE.apart.domain.ApartInfo;
+import com.ssafy.team02_BE.apart.domain.QApartInfo;
+import com.ssafy.team02_BE.dongcode.domain.QDongcode;
+import java.util.List;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Repository;
+
+@Repository
+@RequiredArgsConstructor
+public class ApartQueryRepository {
+    private final JPAQueryFactory queryFactory;
+
+    /**
+     * 동이름으로 아파트 상세 정보 리스트 조회
+     */
+    public List<ApartInfo> getHouseInfosByDongName(String dongName) {
+        QApartInfo apartInfo = QApartInfo.apartInfo;
+        QDongcode dongcode = QDongcode.dongcode;
+        return queryFactory
+            .selectFrom(apartInfo)
+            .join(dongcode).on(apartInfo.sggCd.concat(apartInfo.umdCd).eq(dongcode.dongCode))
+            .where(dongcode.dongName.eq(dongName))
+            .fetch();
+    }
+}

--- a/src/main/java/com/ssafy/team02_BE/apart/service/ApartDealsService.java
+++ b/src/main/java/com/ssafy/team02_BE/apart/service/ApartDealsService.java
@@ -1,0 +1,27 @@
+package com.ssafy.team02_BE.apart.service;
+
+import com.ssafy.team02_BE.apart.domain.ApartDeals;
+import com.ssafy.team02_BE.apart.domain.ApartInfo;
+import com.ssafy.team02_BE.apart.repository.ApartDealsRepository;
+import com.ssafy.team02_BE.apart.repository.ApartInfoRepository;
+import java.util.List;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Service
+@RequiredArgsConstructor
+@Transactional(readOnly = true)
+public class ApartDealsService {
+	private final ApartInfoService apartInfoService;
+	private final ApartDealsRepository apartDealsRepository;
+
+	/**
+	 * aptSeq로 아파트 거래 조회
+	 */
+	public List<ApartDeals> getApartDealsByAptSeq(String aptSeq) throws Exception {
+		// 해당 아파트가 존재하는지 여부
+		apartInfoService.existsByAptSeq(aptSeq);
+		return apartDealsRepository.findByAptSeq(aptSeq);
+	}
+}

--- a/src/main/java/com/ssafy/team02_BE/apart/service/ApartDealsService.java
+++ b/src/main/java/com/ssafy/team02_BE/apart/service/ApartDealsService.java
@@ -22,6 +22,6 @@ public class ApartDealsService {
 	public List<ApartDeals> getApartDealsByAptSeq(String aptSeq) throws Exception {
 		// 해당 아파트가 존재하는지 여부
 		apartInfoService.existsByAptSeq(aptSeq);
-		return apartDealsRepository.findByAptSeq(aptSeq);
+		return apartDealsRepository.findAllByAptSeq(aptSeq);
 	}
 }

--- a/src/main/java/com/ssafy/team02_BE/apart/service/ApartInfoService.java
+++ b/src/main/java/com/ssafy/team02_BE/apart/service/ApartInfoService.java
@@ -1,9 +1,14 @@
 package com.ssafy.team02_BE.apart.service;
 
+import com.ssafy.team02_BE.apart.controller.dto.AptDetailResponseDTO;
+import com.ssafy.team02_BE.apart.domain.ApartDeals;
 import com.ssafy.team02_BE.apart.domain.ApartInfo;
+import com.ssafy.team02_BE.apart.repository.ApartDealsRepository;
 import com.ssafy.team02_BE.apart.repository.ApartInfoRepository;
+import com.ssafy.team02_BE.apart.repository.ApartQueryRepository;
 import com.ssafy.team02_BE.exception.ErrorCode;
 import com.ssafy.team02_BE.exception.model.NotFoundException;
+import java.util.List;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
@@ -14,24 +19,42 @@ import org.springframework.transaction.annotation.Transactional;
 @Transactional(readOnly = true)
 public class ApartInfoService {
 	private final ApartInfoRepository apartInfoRepository;
+	private final ApartQueryRepository apartQueryRepository;
+	private final ApartDealsRepository apartDealsRepository;
 
+	/**
+	 * AptSeq로 아파트 존재 여부 확인
+	 */
 	public Boolean existsByAptSeq(String aptSeq) {
 		if(!apartInfoRepository.existsByAptSeq(aptSeq))
 			throw new NotFoundException(ErrorCode.UNREGISTERED_APART);
 		return true;
 	}
 
-	// 주택 상세 정보 조회
+	/**
+	 * AptSeq로 아파트 상세 정보 조회
+	 */
 	public ApartInfo getApartInfoByAptSeq(String aptSeq) throws Exception {
 		return apartInfoRepository.findByAptSeq(aptSeq);
 	}
 
-//	// 동이름으로 주택 리스트 조회
-//	public List<HouseInfoDealsDTO> getHouseListByDongName(String dongName) throws Exception {
-//		List<HouseInfoDealsDTO> li = apartInfoRepository.getHouseListByDongName(dongName);
-//		MergeSorter.mergeSort(li,
-//				(a, b) -> Integer.compare(b.getHouseInfoDTO().getBuildYear(), a.getHouseInfoDTO().getBuildYear()));
-//		return li;
-//	}
+	/**
+	 * 동이름으로 아파트 상세 정보 리스트 조회
+	 */
+	public List<ApartInfo> getApartInfosByDongName(String dongName) {
+		return apartQueryRepository.getHouseInfosByDongName(dongName);
+	}
+
+	/**
+	 * AptSeq로 아파트 상세(아파트 상세 정보 + 아파트 거래 정보 리스트) 조회
+	 */
+	public AptDetailResponseDTO getApartDetailsByAptSeq(String aptSeq) throws Exception {
+		ApartInfo apartInfo = getApartInfoByAptSeq(aptSeq);
+
+		// aptSeq로 최신순 100개의 거래량 조회
+		List<ApartDeals> deals = apartDealsRepository.findTop100ByAptSeqOrderByDealYearDescDealMonthDesc(aptSeq);
+
+		return AptDetailResponseDTO.of(aptSeq, apartInfo, deals);
+	}
 
 }

--- a/src/main/java/com/ssafy/team02_BE/apart/service/ApartInfoService.java
+++ b/src/main/java/com/ssafy/team02_BE/apart/service/ApartInfoService.java
@@ -34,21 +34,23 @@ public class ApartInfoService {
 	/**
 	 * AptSeq로 아파트 상세 정보 조회
 	 */
-	public ApartInfo getApartInfoByAptSeq(String aptSeq) throws Exception {
-		return apartInfoRepository.findByAptSeq(aptSeq);
+	public ApartInfo getApartInfoByAptSeq(String aptSeq) {
+		existsByAptSeq(aptSeq); // 존재 여부 검증
+		return apartInfoRepository.findByAptSeq(aptSeq).get();
 	}
 
 	/**
 	 * 동이름으로 아파트 상세 정보 리스트 조회
 	 */
 	public List<ApartInfo> getApartInfosByDongName(String dongName) {
-		return apartQueryRepository.getHouseInfosByDongName(dongName);
+		return apartQueryRepository.getApartInfosByDongName(dongName);
 	}
 
 	/**
 	 * AptSeq로 아파트 상세(아파트 상세 정보 + 아파트 거래 정보 리스트) 조회
 	 */
 	public AptDetailResponseDTO getApartDetailsByAptSeq(String aptSeq) throws Exception {
+		existsByAptSeq(aptSeq); // 존재 여부 검증
 		ApartInfo apartInfo = getApartInfoByAptSeq(aptSeq);
 
 		// aptSeq로 최신순 100개의 거래량 조회

--- a/src/main/java/com/ssafy/team02_BE/apart/service/ApartInfoService.java
+++ b/src/main/java/com/ssafy/team02_BE/apart/service/ApartInfoService.java
@@ -1,0 +1,37 @@
+package com.ssafy.team02_BE.apart.service;
+
+import com.ssafy.team02_BE.apart.domain.ApartInfo;
+import com.ssafy.team02_BE.apart.repository.ApartInfoRepository;
+import com.ssafy.team02_BE.exception.ErrorCode;
+import com.ssafy.team02_BE.exception.model.NotFoundException;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Service
+@RequiredArgsConstructor
+// JPA에서 쓰기 지연 저장소를 비활성화하고, 변경 감지 기능을 끔 TODO; 추가 공부
+@Transactional(readOnly = true)
+public class ApartInfoService {
+	private final ApartInfoRepository apartInfoRepository;
+
+	public Boolean existsByAptSeq(String aptSeq) {
+		if(!apartInfoRepository.existsByAptSeq(aptSeq))
+			throw new NotFoundException(ErrorCode.UNREGISTERED_APART);
+		return true;
+	}
+
+	// 주택 상세 정보 조회
+	public ApartInfo getApartInfoByAptSeq(String aptSeq) throws Exception {
+		return apartInfoRepository.findByAptSeq(aptSeq);
+	}
+
+//	// 동이름으로 주택 리스트 조회
+//	public List<HouseInfoDealsDTO> getHouseListByDongName(String dongName) throws Exception {
+//		List<HouseInfoDealsDTO> li = apartInfoRepository.getHouseListByDongName(dongName);
+//		MergeSorter.mergeSort(li,
+//				(a, b) -> Integer.compare(b.getHouseInfoDTO().getBuildYear(), a.getHouseInfoDTO().getBuildYear()));
+//		return li;
+//	}
+
+}

--- a/src/main/java/com/ssafy/team02_BE/config/QuerydslConfig.java
+++ b/src/main/java/com/ssafy/team02_BE/config/QuerydslConfig.java
@@ -1,0 +1,19 @@
+package com.ssafy.team02_BE.config;
+
+import com.querydsl.jpa.impl.JPAQueryFactory;
+import jakarta.persistence.EntityManager;
+import jakarta.persistence.PersistenceContext;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+
+@Configuration
+public class QuerydslConfig {
+
+    @PersistenceContext
+    private EntityManager em;
+
+    @Bean
+    public JPAQueryFactory jpaQueryFactory(EntityManager em) {
+        return new JPAQueryFactory(em);
+    }
+}

--- a/src/main/java/com/ssafy/team02_BE/dongcode/domain/Dongcode.java
+++ b/src/main/java/com/ssafy/team02_BE/dongcode/domain/Dongcode.java
@@ -1,0 +1,19 @@
+package com.ssafy.team02_BE.dongcode.domain;
+
+import jakarta.persistence.Entity;
+import jakarta.persistence.Id;
+import lombok.AccessLevel;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Entity
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class Dongcode {
+	@Id
+	private String dongCode;
+	private String sidoName;
+	private String gugunName;
+	private String dongName;
+
+}

--- a/src/main/java/com/ssafy/team02_BE/exception/ErrorCode.java
+++ b/src/main/java/com/ssafy/team02_BE/exception/ErrorCode.java
@@ -30,6 +30,10 @@ public enum ErrorCode {
     MISSING_CLAIM_TOKEN(HttpStatus.UNAUTHORIZED, "정보가 누락된 토큰입니다."),
     INVALID_TOKEN_PAYLOAD(HttpStatus.UNAUTHORIZED, "토큰 payload가 유효하지 않습니다."),
     UNAUTHORIZED_TOKEN(HttpStatus.UNAUTHORIZED, "유효하지 않은 토큰입니다."),
+
+    // apart
+    UNREGISTERED_APART(HttpStatus.NOT_FOUND, "등록되지 않은 아파트입니다."),
+
     ;
 
     private final HttpStatus code;

--- a/src/main/java/com/ssafy/team02_BE/exception/SuccessCode.java
+++ b/src/main/java/com/ssafy/team02_BE/exception/SuccessCode.java
@@ -14,6 +14,9 @@ public enum SuccessCode {
     TOKEN_REFRESH_SUCCESS(HttpStatus.OK, "토큰 재발급에 성공했습니다."),
     WITHDRAW_SUCCESS(HttpStatus.OK, "탈퇴에 성공했습니다."),
 
+    // apart
+    GET_APARTINFO_BY_APTSEQ(HttpStatus.OK, "아파트 상세 정보 조회에 성공했습니다."),
+    GET_APARTDEALS_BY_APTSEQ(HttpStatus.OK, "아파트 거래 조회에 성공했습니다."),
     // user
 //    NICKNAME_CHECK_SUCCESS(HttpStatus.OK, "닉네임 중복 확인에 성공했습니다."),
 //    CHANGE_NICKNAME_SUCCESS(HttpStatus.OK, "닉네임 변경에 성공했습니다."),

--- a/src/main/java/com/ssafy/team02_BE/exception/SuccessCode.java
+++ b/src/main/java/com/ssafy/team02_BE/exception/SuccessCode.java
@@ -17,6 +17,8 @@ public enum SuccessCode {
     // apart
     GET_APARTINFO_BY_APTSEQ(HttpStatus.OK, "아파트 상세 정보 조회에 성공했습니다."),
     GET_APARTDEALS_BY_APTSEQ(HttpStatus.OK, "아파트 거래 조회에 성공했습니다."),
+    GET_APARTINFOS_BY_DONGNAME(HttpStatus.OK, "동이름으로 아파트 검색에 성공했습니다."),
+    GET_APARTDETAILS_BY_APTSEQ(HttpStatus.OK, "아파트 상세 정보와 거래 조회에 성공했습니다."),
     // user
 //    NICKNAME_CHECK_SUCCESS(HttpStatus.OK, "닉네임 중복 확인에 성공했습니다."),
 //    CHANGE_NICKNAME_SUCCESS(HttpStatus.OK, "닉네임 변경에 성공했습니다."),

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -12,8 +12,8 @@ spring.datasource.password=${DB_PASSWORD}
 # none
 spring.jpa.hibernate.ddl-auto=update
 spring.jpa.hibernate.naming.physical-strategy=org.hibernate.boot.model.naming.PhysicalNamingStrategyStandardImpl
-#spring.jpa.show-sql=true
-#logging.level.org.hibernate.type.descriptor.sql=trace
+spring.jpa.show-sql=true
+logging.level.org.hibernate.type.descriptor.sql=trace
 
 # swagger
 springdoc.version = v1


### PR DESCRIPTION
### 🔥 PR 요약

- ApartInfo(아파트 상세 정보), ApartDeal(아파트 거래) 엔티티 생성
- Dongcode(동 코드) 엔티티 생성
- 동이름으로 아파트 검색, 아파트 상세 정보 조회, 아파트 거래 조회 API 구현
- Querydsl 의존성 추가

### ✅ 작업 유형

- [x] 새로운 기능 추가 (feat)
- [ ] 버그 수정 (fix)
- [ ] 리팩토링 (refactor)
- [ ] 문서 수정 (docs)
- [ ] 테스트 추가 또는 수정 (test)
- [x] 빌드 설정 변경 (build)
- [ ] CI/CD 설정 변경 (ci)
- [ ] 기타 설정 변경 (chore, style 등)

### 📌 관련 이슈
  close #5 

### 🧪 테스트 결과 
| API        | 테스트 결과 이미지 |
|------------|-------------------|
| 아파트 상세조회 | <img width="1062" alt="image" src="https://github.com/user-attachments/assets/70a95a33-de6f-4e15-8add-5b60de79c217" /> |
| 동이름으로 아파트 리스트 검색     | <img width="829" alt="image" src="https://github.com/user-attachments/assets/1fdd7b51-1b3f-4911-a453-f0220a4d274f" /> |
| 아파트 상세 + 거래 리스트 조회   |<img width="949" alt="image" src="https://github.com/user-attachments/assets/2ca72123-83f5-4cb5-be13-2a03ccb1a24b" /> |
| 아파트 거래 리스트 조회 | <img width="994" alt="image" src="https://github.com/user-attachments/assets/ebc429fe-fa9d-4dc4-b0fb-6506e58c1cfd" /> |

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **신규 기능**
  - 아파트 정보 및 거래 내역 조회를 위한 REST API가 추가되었습니다. (아파트 상세 정보, 거래 내역, 동이름으로 아파트 검색 등)
  - 아파트 및 동코드 관련 엔티티와 데이터 전송 객체(DTO)가 추가되었습니다.
  - 아파트 정보 및 거래 내역을 효율적으로 조회할 수 있는 서비스 및 저장소가 도입되었습니다.

- **설정**
  - Querydsl 및 JPA 관련 의존성과 설정이 추가되어, 보다 복잡한 쿼리 작성이 가능해졌습니다.
  - SQL 쿼리 및 Hibernate 타입 로깅이 활성화되었습니다.

- **에러 및 성공 코드**
  - 아파트 정보 조회 및 거래 내역 조회에 대한 성공/실패 메시지가 추가되었습니다.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->