### PR TITLE
[FEAT] 프론트엔드에서 해싱된 비밀번호 평문 저장으로 변경

### DIFF
--- a/src/main/java/com/ssafy/team02_BE/auth/controller/dto/LoginRequestDTO.java
+++ b/src/main/java/com/ssafy/team02_BE/auth/controller/dto/LoginRequestDTO.java
@@ -17,6 +17,10 @@ public class LoginRequestDTO {
     private String password;
 
     public UsernamePasswordAuthenticationToken toAuthentication() {
-        return new UsernamePasswordAuthenticationToken(email, password);
+        return new UsernamePasswordAuthenticationToken(email, getPassword());
+    }
+
+    public String getPassword() {
+        return "{noop}" + password;
     }
 }

--- a/src/main/java/com/ssafy/team02_BE/auth/controller/dto/SignupRequestDTO.java
+++ b/src/main/java/com/ssafy/team02_BE/auth/controller/dto/SignupRequestDTO.java
@@ -15,4 +15,8 @@ public class SignupRequestDTO {
 	private String nickname;
 	private String name;
 	private String phoneNumber;
+
+	public String getPassword() {
+		return "{noop}" + password;
+	}
 }

--- a/src/main/java/com/ssafy/team02_BE/auth/service/AuthService.java
+++ b/src/main/java/com/ssafy/team02_BE/auth/service/AuthService.java
@@ -6,19 +6,18 @@ import com.ssafy.team02_BE.auth.controller.dto.SignupRequestDTO;
 import com.ssafy.team02_BE.auth.controller.dto.SignupResponseDTO;
 import com.ssafy.team02_BE.auth.domain.Refresh;
 import com.ssafy.team02_BE.auth.domain.Role;
-import com.ssafy.team02_BE.user.domain.User;
 import com.ssafy.team02_BE.auth.repository.RefreshRepository;
-import com.ssafy.team02_BE.user.repository.UserRepository;
 import com.ssafy.team02_BE.exception.ErrorCode;
 import com.ssafy.team02_BE.exception.model.ConflictException;
 import com.ssafy.team02_BE.exception.model.NotFoundException;
 import com.ssafy.team02_BE.security.jwt.Jwt;
 import com.ssafy.team02_BE.security.jwt.JwtProvider;
+import com.ssafy.team02_BE.user.domain.User;
+import com.ssafy.team02_BE.user.repository.UserRepository;
 import lombok.RequiredArgsConstructor;
 import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
 import org.springframework.security.config.annotation.authentication.builders.AuthenticationManagerBuilder;
 import org.springframework.security.core.Authentication;
-import org.springframework.security.crypto.password.PasswordEncoder;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
@@ -32,7 +31,7 @@ public class AuthService {
     private final UserRepository userRepository;
     private final JwtProvider jwtProvider;
     private final RefreshRepository refreshRepository;
-    private final PasswordEncoder passwordEncoder;
+    //    private final PasswordEncoder passwordEncoder;
     private final AuthenticationManagerBuilder authenticationManagerBuilder;
 
     /**
@@ -42,7 +41,6 @@ public class AuthService {
     public LoginResponseDTO login(LoginRequestDTO loginRequestDTO) {
         // DTO로부터 email, password를 꺼내 token 생성
         UsernamePasswordAuthenticationToken authenticationToken = loginRequestDTO.toAuthentication();
-
         // 실제 검증 (사용자 비밀번호 체크) 이 이루어지는 부분
         // ID 존재 여부 + 해당 ID로 불러온 비밀번호가 사용자가 제출한 비밀번호와 일치하는지 겅즘
         //   authenticate 메서드가 실행이 될 때 CustomUserDetailsService 에서 만들었던 loadUserByUsername 메서드가 실행됨
@@ -76,7 +74,8 @@ public class AuthService {
         User signupUser = User.builder()
                 .nickname(signupRequestDTO.getNickname())
                 .email(signupRequestDTO.getEmail())
-                .password(passwordEncoder.encode(signupRequestDTO.getPassword()))
+//                .password(passwordEncoder.encode(signupRequestDTO.getPassword()))
+                .password(signupRequestDTO.getPassword())
                 .name(signupRequestDTO.getName())
                 .phoneNumber(signupRequestDTO.getPhoneNumber())
                 .roles(Role.USER.name())

--- a/src/main/java/com/ssafy/team02_BE/config/SecurityConfig.java
+++ b/src/main/java/com/ssafy/team02_BE/config/SecurityConfig.java
@@ -11,7 +11,8 @@ import org.springframework.security.config.annotation.web.configuration.EnableWe
 import org.springframework.security.config.annotation.web.configurers.AbstractHttpConfigurer;
 import org.springframework.security.config.annotation.web.configurers.HeadersConfigurer;
 import org.springframework.security.config.http.SessionCreationPolicy;
-import org.springframework.security.crypto.bcrypt.BCryptPasswordEncoder;
+import org.springframework.security.crypto.password.NoOpPasswordEncoder;
+import org.springframework.security.crypto.password.PasswordEncoder;
 import org.springframework.security.web.SecurityFilterChain;
 import org.springframework.security.web.authentication.UsernamePasswordAuthenticationFilter;
 
@@ -23,10 +24,16 @@ public class SecurityConfig {
     private final JwtFilter jwtFilter;
     private final JwtExceptionHandlerFilter jwtExceptionHandlerFilter;
 
-    @Bean
-    public BCryptPasswordEncoder bCryptPasswordEncoder() {
+//    @Bean
+//    public BCryptPasswordEncoder bCryptPasswordEncoder() {
+//
+//        return new BCryptPasswordEncoder();
+//    }
 
-        return new BCryptPasswordEncoder();
+    @Bean
+    public PasswordEncoder passwordEncoder() {
+        // NoOpPasswordEncoder는 비밀번호를 평문으로 처리
+        return NoOpPasswordEncoder.getInstance();
     }
 
     // 인증 없이 접근 가능한 경로

--- a/src/main/java/com/ssafy/team02_BE/user/controller/dto/UserUpdateRequestDTO.java
+++ b/src/main/java/com/ssafy/team02_BE/user/controller/dto/UserUpdateRequestDTO.java
@@ -14,4 +14,8 @@ public class UserUpdateRequestDTO {
     private String nickname;
     private String name;
     private String phoneNumber;
+
+    public String getPassword() {
+        return "{noop}" + password;
+    }
 }

--- a/src/main/java/com/ssafy/team02_BE/user/domain/User.java
+++ b/src/main/java/com/ssafy/team02_BE/user/domain/User.java
@@ -73,8 +73,12 @@ public class User extends BaseEntity implements UserDetails {
         return getEmail();
     }
 
-    public void setPassword(PasswordEncoder passwordEncoder, String password) {
-        this.password = passwordEncoder.encode(password);
+//    public void setPassword(PasswordEncoder passwordEncoder, String password) {
+//        this.password = passwordEncoder.encode(password);
+//    }
+
+    public void setPassword(String password) {
+        this.password = password;
     }
 
     public void setNickname(String nickname) {

--- a/src/main/java/com/ssafy/team02_BE/user/service/UserService.java
+++ b/src/main/java/com/ssafy/team02_BE/user/service/UserService.java
@@ -15,7 +15,7 @@ import org.springframework.transaction.annotation.Transactional;
 @RequiredArgsConstructor
 public class UserService {
     private final UserRepository userRepository;
-    private final PasswordEncoder passwordEncoder;
+//    private final PasswordEncoder passwordEncoder;
 
     /**
      * 유저 정보 수정
@@ -26,7 +26,8 @@ public class UserService {
             .orElseThrow(() -> new NotFoundException(ErrorCode.UNREGISTERED_USER));
 
         user.setNickname(userUpdateRequestDTO.getNickname());
-        user.setPassword(passwordEncoder, userUpdateRequestDTO.getPassword());
+//        user.setPassword(passwordEncoder, userUpdateRequestDTO.getPassword());
+        user.setPassword(userUpdateRequestDTO.getPassword());
         user.setName(userUpdateRequestDTO.getName());
         user.setPhoneNumber(userUpdateRequestDTO.getPhoneNumber());
 


### PR DESCRIPTION
### 🔥 PR 요약

- 프론트엔드에서 해싱된 비밀번호 평문 저장으로 변경

### ✅ 작업 유형

- [x] 새로운 기능 추가 (feat)
- [ ] 버그 수정 (fix)
- [ ] 리팩토링 (refactor)
- [ ] 문서 수정 (docs)
- [ ] 테스트 추가 또는 수정 (test)
- [ ] 빌드 설정 변경 (build)
- [ ] CI/CD 설정 변경 (ci)
- [ ] 기타 설정 변경 (chore, style 등)

### 📌 관련 이슈
  close #21

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- 회원가입, 로그인, 회원정보 수정 시 비밀번호를 평문(암호화 없이)으로 처리하도록 변경되었습니다.

- **Refactor**
	- 비밀번호 저장 및 인증 방식이 암호화(Bcrypt)에서 평문(NoOp) 방식으로 변경되었습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->